### PR TITLE
Fixed an error about unshift stack

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-undo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [
     "Matthias Jouan <matthias.jouan@gmail.com>"
   ],

--- a/lib/simple-undo.js
+++ b/lib/simple-undo.js
@@ -51,7 +51,7 @@ SimpleUndo.prototype.clear = function() {
 
 SimpleUndo.prototype.save = function() {
 	this.provider(function(current) {
-		truncate(this.stack, this.maxLength);
+		if (this.position >= this.maxLength) truncate(this.stack, this.maxLength);
 		this.position = Math.min(this.position,this.stack.length - 1);
 
 		this.stack = this.stack.slice(0, this.position + 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-undo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "a very basic javascript undo/redo stack for managing histories of basically anything",
   "main": "./lib/simple-undo.js",
   "scripts": {

--- a/tests/simple-undo.js
+++ b/tests/simple-undo.js
@@ -151,4 +151,31 @@ describe('SimpleUndo', function() {
 		});
 		
 	});
+
+	it('should reserve initial when undo position to be 0 and save', function() {
+		var count = 0;
+		var provider = function(done) {
+			done(count++);
+		}
+
+		var history = new SimpleUndo({
+			provider: provider,
+			maxLength: 3
+		});
+
+		history.initialize('initial');
+		history.save();
+		history.save();
+		history.save();
+		history.undo();
+		history.undo();
+		history.undo();
+
+		history.canUndo().should.be.false;
+		history.count().should.equal(3);
+		history.save();
+		history.stack.length.should.equal(2);
+		history.stack[0].should.equal('initial');
+		history.stack[1].should.equal(3);
+	});
 })


### PR DESCRIPTION
Hello mattjmattj,

I found a bug about unshift `stack`.

When the `stack` length is greater than `maxLength`,
to call `undo` method than calling `save` method,
first history will be removed.

But `position` is less than `maxLength`, it shouldn't be removed.
